### PR TITLE
fix: Turn off the brp-python-bytecompile automagic

### DIFF
--- a/resources/packaging/arcticstack.spec.in
+++ b/resources/packaging/arcticstack.spec.in
@@ -4,6 +4,9 @@
 nic_nmcli ofed ofed_sm openldap_client openldap_server powerman prometheus_client \
 prometheus_server report root_password singularity slurm sssd users_basic
 
+# Turn off the brp-python-bytecompile automagic
+%global _python_bytecompile_extra 0
+
 Name:           arcticstack
 Version:        %{version}
 Release:        1%{?dist}


### PR DESCRIPTION
When building the rpms for el7 (python 2.7), the Python byte-compiling
fail on extra Python 3 files which are installed by Ansible roles.
There is no reason to byte-compile these extra files. Disable this
behavior in the spec file.

See:
https://fedoraproject.org/wiki/Changes/No_more_automagic_Python_bytecompilation