### PR TITLE
fix: Turn off the brp-python-bytecompile script

### DIFF
--- a/resources/packaging/arcticstack.spec.in
+++ b/resources/packaging/arcticstack.spec.in
@@ -7,6 +7,11 @@ prometheus_server report root_password singularity slurm sssd users_basic
 # Turn off the brp-python-bytecompile automagic
 %global _python_bytecompile_extra 0
 
+%if 0%{?el7}
+# Turn off the brp-python-bytecompile script
+%global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-python-bytecompile[[:space:]].*$!!g')
+%endif
+
 Name:           arcticstack
 Version:        %{version}
 Release:        1%{?dist}


### PR DESCRIPTION
Turn off the brp-python-bytecompile automagic is not enough for el7.
Turn off the script when OS is el7.